### PR TITLE
HPianoRoll.hpp: Add include to fix build with gcc12

### DIFF
--- a/BWidgets/HPianoRoll.hpp
+++ b/BWidgets/HPianoRoll.hpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <cstdint>
 #include <vector>
+#include <array>
 
 #ifndef BWIDGETS_DEFAULT_HPIANOROLL_WIDTH
 #define BWIDGETS_DEFAULT_HPIANOROLL_WIDTH 400.0


### PR DESCRIPTION
BLow fails build on gcc 12 with:

| Build BLow.lv2 GUI...In file included from ../../src/BLow_GUI.cpp:10:
| ../../src/../BWidgets/BWidgets/HPianoRoll.hpp:348:42: error: variable 'constexpr const std::array<BWidgets::PianoKeyCoords, 12> BWidgets::keyCoords' has initializer but incomplete type
|   348 | constexpr std::array<PianoKeyCoords, 12> keyCoords=
|       |                                          ^~~~~~~~~
| ../../src/BLow_GUI.cpp:37:63: error: field 'controllerWidgets' has incomplete type 'std::array<BWidgets::Valueable*, 4>'
|    37 |         std::array<BWidgets::Valueable*, BLOW_NR_CONTROLLERS> controllerWidgets;
|       |                                                               ^~~~~~~~~~~~~~~~~
| In file included from /home/superandy/tmp/oe-core-glibc/work/cortexa72-mortsgna-linux/blow/1.2.0-r0/recipe-sysroot/usr/include/c++/12.1.0/functional:54,
|                  from ../../src/../BWidgets/BWidgets/Widget.hpp:22,
|                  from ../../src/../BWidgets/BWidgets/Window.hpp:25,
|                  from ../../src/BLow_GUI.cpp:7:

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>